### PR TITLE
Update GNodePaths.java

### DIFF
--- a/GNodePaths.java
+++ b/GNodePaths.java
@@ -7,7 +7,41 @@ import java.util.ArrayList;
 public class GNodePaths{
    public static void main(String[] args){
    
-      public ArrayList<ArrayList<GNode>> paths(GNode node){
+         /* Create a graph of GNodes */
+      
+        // Allocate memory to hold list of GNodes in graph
+        ArrayList<ArrayList<GNode>> paths = new ArrayList<ArrayList<GNode>>();
+        
+        // Call function to generate arraylist of all GNode paths from graph
+        paths = findPaths(/* insert root GNode */);
+        
+        // Print all paths through GNodes in graph with each GNode represented by its name
+        System.out.println("All paths in directed graph from given root GNode:");
+        
+        // Loop through each arraylist, then start print of path with a tab and an open parentheses
+        for (int i = 0; i < paths.size(); i++){
+           System.out.print("\t\(");
+           
+           // Loop through each GNode in arraylist path and print path represented by the GNodes' names
+           for(int j = 0; j < paths.get(i).size(); j++){
+              
+              // if leaf node, print GNode name, close parentheses, then move to next line
+              if (j == paths.get(i).size() - 1){
+                 System.out.print(paths.get(i).get(j).getName() + "\)\n");
+              }
+              // if root or internal node, just print name with comma
+              else {
+                 System.out.print(paths.get(i).get(j).getName() + ", ");
+              }
+           }
+        }    
+   }
+
+   /* Method call to return an arraylist of GNode arraylists representing paths in a directed graph between a passed in a root and
+   *   all of its children leaf nodes
+   *  This particular call serves as a wrapper function for findPaths()
+   */
+   public ArrayList<ArrayList<GNode>> paths(GNode node){
       
          // create ArrayList to hold ArrayLists of GNodes
          ArrayList<ArrayList<GNode>> returnMe = new ArrayList<ArraList<GNode>>();
@@ -20,9 +54,8 @@ public class GNodePaths{
          
          // send updated ArrayList to function call
          return returnMe;        
-      }   
    }
-
+   
    /* This function passes in a GNode of a directed graph and generates an arraylist of GNode arraylists 
    *     representing all possible paths from the passed in node to its leaf nodes
    *  function receives the following arguments:


### PR DESCRIPTION
moved method call paths() outside of main method, and wrote code to test the method.  the result is a print out of all the paths, where the names of GNodes in a path are printed on a line from root to leaf.  each path is printed on a new line.